### PR TITLE
Fix: in light mode, low contrast button is now properly hidden

### DIFF
--- a/sass/components/misc.scss
+++ b/sass/components/misc.scss
@@ -149,8 +149,8 @@ body > * {
 	transition: all 1s ease;
 }
 
-#theme-normal-contrast,
-#theme-low-contrast {
+// Hide the low contrast button by default - individual themes can toggle it back on.
+label[for="low-contrast"] {
 	display: none;
 }
 
@@ -280,9 +280,9 @@ body {
 // Set the tab-stop to 4 for now, allowing it to be customized via CSS variables
 
 :root {
-  --tab-stop: 4;
+	--tab-stop: 4;
 }
 
 * {
-  tab-size: var(--tab-stop);
+	tab-size: var(--tab-stop);
 }

--- a/sass/components/toggles.scss
+++ b/sass/components/toggles.scss
@@ -1,38 +1,43 @@
-
 #language-switcher:checked ~ {
-  #language-modal {
-	display: flex;
-  }
+	#language-modal {
+		display: flex;
+	}
 }
 
-#low-contrast:checked ~ {
-  * {
-	filter: brightness(70%) contrast(90%) saturate(90%);
-  }
-
-  section {
-	#theme-low-contrast {
-	  display: block;
+#low-contrast {
+	&:not(:checked) ~ section {
+		#theme-low-contrast {
+			display: none;
+		}
 	}
+	&:checked ~ {
+		* {
+			filter: brightness(70%) contrast(90%) saturate(90%);
+		}
+		section {
+			#theme-low-contrast {
+				display: block;
+			}
 
-	#theme-normal-contrast {
-	  display: none;
+			#theme-normal-contrast {
+				display: none;
+			}
+		}
 	}
-  }
 }
 
 #toggle-navbar:checked ~ {
-  section .navbar-menu {
-	display: block;
-  }
+	section .navbar-menu {
+		display: block;
+	}
 
-  nav .navbar-menu {
-	display: block;
-  }
+	nav .navbar-menu {
+		display: block;
+	}
 }
 
 #toggle-sidebar:checked ~ {
-  div .sidebar {
-	display: block !important;
-  }
+	div .sidebar {
+		display: block !important;
+	}
 }

--- a/sass/themes/dark/misc.scss
+++ b/sass/themes/dark/misc.scss
@@ -23,9 +23,9 @@ span.inline-divider {
   }
 }
 
-
-#theme-normal-contrast {
-	display: block;
+// Enable low contrast button
+label[for="low-contrast"] {
+	display: flex;
 }
 
 /* For the low-contrast peeps out there, we'll do some filtering. Best we can do for now. */
@@ -35,8 +35,7 @@ span.inline-divider {
 		filter: brightness(70%) contrast(90%) saturate(90%);
 	}
 
-	#theme-normal-contrast,
-	#theme-low-contrast {
+	label[for="low-contrast"] {
 		display: none !important;
 	}
 }


### PR DESCRIPTION
As discussed over Discord, the low contrast switch is supposed be hidden in light mode and dark mode users under low-contrast mode. However, the current implementation does not actually hide the interactive section of the switch—it merely hides the two icons of the switch—the actual switch is still functional.

This PR makes the switch's `label` element hidden by default—completely disabling the switch as intended—and that the dark theme separately enables the switch.