### PR TITLE
Modify style to work with tabs

### DIFF
--- a/sass/common/derived.scss
+++ b/sass/common/derived.scss
@@ -18,3 +18,7 @@ $pre-border: 1px solid darken($dark, 20%);
 $navbar-transparent-background: rgba(255, 255, 255, 0.3) !default;
 
 $transparent-text: transparentize($text, 0.7);
+
+.content .tabs ul {
+    margin-left: 0;
+}

--- a/sass/themes/dark/vars.scss
+++ b/sass/themes/dark/vars.scss
@@ -76,10 +76,15 @@ $body-background-color: $neutral-background;
 $footer-background-color: #1c1526;
 
 $tabs-boxed-link-active-background-color: $body-background-color;
+$tabs-boxed-link-hover-background-color: $dark;
 
 $code: lighten($primary, 20%);
 $code-background: $dark;
 $pre-background: $dark;
+
+$tabs-link-active-color: $code;
+$tabs-link-hover-color: $code;
+$tabs-link-color: $code;
 
 $box-background-color: $dark;
 $tag-background-color: $dark;

--- a/sass/themes/light/vars.scss
+++ b/sass/themes/light/vars.scss
@@ -77,6 +77,10 @@ $message-header-color: $text;
 $code-background: $primary-lighter;
 $code: $primary-dark;
 
+$tabs-link-active-color: $code;
+$tabs-link-hover-color: $code;
+$tabs-link-color: $code;
+
 $pre-background: $primary-lighter;
 
 $tag-background-color: $primary-lighter;


### PR DESCRIPTION
Currently, the quilt-bulma style doesn't work too well with bulma tabs in page content: the tabs are unreadable on dark mode when hovered over, and as tabs are made with an unordered list, they end up indented when they shouldn't be.

This PR is made to accompany QuiltMC/developer-wiki#43

Disclaimer: I'm not very good at CSS/SCSS, so please poke at whatever I may have messed up