### PR TITLE
Update Mastodon's colors to reflect rebranding

### DIFF
--- a/sass/themes/dark/vars.scss
+++ b/sass/themes/dark/vars.scss
@@ -49,7 +49,7 @@ $twitter-blue: #1da1f2;
 $twitter-blue-dark: darken($twitter-blue, 3%);
 $twitter-blue-light: lighten($twitter-blue, 3%);
 
-$mastodon-blue: #3088d4;
+$mastodon-blue: #6364ff;
 $mastodon-blue-dark: darken($mastodon-blue, 3%);
 $mastodon-blue-light: lighten($mastodon-blue, 3%);
 

--- a/sass/themes/light/vars.scss
+++ b/sass/themes/light/vars.scss
@@ -42,7 +42,7 @@ $twitter-blue: #1da1f2;
 $twitter-blue-dark: darken($twitter-blue, 3%);
 $twitter-blue-light: lighten($twitter-blue, 3%);
 
-$mastodon-blue: #3088d4;
+$mastodon-blue: #6364ff;
 $mastodon-blue-dark: darken($mastodon-blue, 3%);
 $mastodon-blue-light: lighten($mastodon-blue, 3%);
 


### PR DESCRIPTION
Yes, I'm the kind of person who would have pushed for updating Discord's blurple and icon and yes! I hate the past! (but seriously, the old mastodon blue looks ugly);

With the rebranding changing the colors, I've updated the Mastodon colors in order to reflect that:
![Cropped screenshot of the QuiltMC website showing the community buttons, with Mastodon's button being recolored to a blurple-like color](https://user-images.githubusercontent.com/85590273/202861277-f94fb2ea-5f99-40ca-9b93-cfd53d69d273.png)

Note: maybe `mastodon-blue` isn't an accurate name anymore? It was tempting to call it `mastodon-blurple` but yeah, that term is 100% a Discord thing